### PR TITLE
[#4] Update InMemoryFeatureRepository::remove contract with a Feature instead of FeatureId

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "pheature/toggle-core": "^0.1",
-        "pheature/toggle-model": "^0.1",
+        "pheature/toggle-core": "^0.2",
+        "pheature/toggle-model": "^0.2",
         "webmozart/assert": "^1.10"
     },
     "require-dev": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,4 @@
 grumphp:
-    git_hook_variables:
-        EXEC_GRUMPHP_COMMAND: 'docker run -e "TERM=xterm-256color" --tty=true --rm -v $PWD:/code:cached pheature/pheature-php-dev:latest'
     hooks_dir: .
     hooks_preset: local
     tasks:

--- a/src/InMemoryFeatureRepository.php
+++ b/src/InMemoryFeatureRepository.php
@@ -18,9 +18,9 @@ final class InMemoryFeatureRepository implements FeatureRepository
         $this->features[$feature->id()] = $feature;
     }
 
-    public function remove(FeatureId $featureId): void
+    public function remove(Feature $feature): void
     {
-        unset($this->features[$featureId->value()]);
+        unset($this->features[$feature->id()]);
     }
 
     public function get(FeatureId $featureId): Feature

--- a/test/InMemoryFeatureRepositoryTest.php
+++ b/test/InMemoryFeatureRepositoryTest.php
@@ -40,7 +40,7 @@ final class InMemoryFeatureRepositoryTest extends TestCase
         $repository = new InMemoryFeatureRepository();
         $repository->save($feature);
         self::assertSame($feature, $repository->get($featureId));
-        $repository->remove($featureId);
+        $repository->remove($feature);
         $repository->get($featureId);
     }
 }


### PR DESCRIPTION
Blocked by: https://github.com/pheature-flags/toggle-core/pull/31 and https://github.com/pheature-flags/toggle-model/pull/10
Closes #4 